### PR TITLE
Make gpmf-extract usable in a Worker

### DIFF
--- a/code/readBlock.js
+++ b/code/readBlock.js
@@ -1,42 +1,43 @@
-//Read chunks progressively in browser
-var chunkSize = 1024 * 1024 * 2; // bytes
-var offsetFlag = 0;
-var offset = 0;
-var gotSamples;
+module.exports = function() {
+  //Read chunks progressively in browser
+  var chunkSize = 1024 * 1024 * 2; // bytes
+  var offsetFlag = 0;
+  var offset = 0;
+  var gotSamples;
 
-function stop() {
-  gotSamples = true;
+  function stop() {
+    gotSamples = true;
+  }
+
+  //We get functions to run on certain event from parent function
+  function read(file, { update, onparsedbuffer, mp4boxFile }) {
+    var fileSize = file.size;
+    var r = new FileReader();
+    var blob = file.slice(offset, chunkSize + offset);
+    r.onload = function(evt) {
+      if (evt.target.error == null) {
+        //Tell parent function to add data to mp4box
+        onparsedbuffer(evt.target.result, offset);
+        //Record offset for next chunk
+        offset += evt.target.result.byteLength;
+        //Provide proress percentage to parent function
+        const prog = Math.ceil((50 * offset) / fileSize) + 50 * offsetFlag;
+        if (update) update(prog);
+      } else reject('Read error: ' + evt.target.error, '');
+
+      //Adapt offset to larger file sizes
+      if (offset >= fileSize) {
+        //Tell parent function to flush mp4box
+        mp4boxFile.flush();
+        offset = 0;
+        offsetFlag++;
+        if (!gotSamples) read(file, { update, onparsedbuffer, mp4boxFile });
+        return;
+      }
+      read(file, { update, onparsedbuffer, mp4boxFile });
+    };
+    //Use the FileReader
+    r.readAsArrayBuffer(blob);
+  }
+  return { read, stop };
 }
-
-//We get functions to run on certain event from parent function
-function read(file, { update, onparsedbuffer, mp4boxFile }) {
-  var fileSize = file.size;
-  var r = new FileReader();
-  var blob = file.slice(offset, chunkSize + offset);
-  r.onload = function(evt) {
-    if (evt.target.error == null) {
-      //Tell parent function to add data to mp4box
-      onparsedbuffer(evt.target.result, offset);
-      //Record offset for next chunk
-      offset += evt.target.result.byteLength;
-      //Provide proress percentage to parent function
-      const prog = Math.ceil((50 * offset) / fileSize) + 50 * offsetFlag;
-      if (update) update(prog);
-    } else reject('Read error: ' + evt.target.error, '');
-
-    //Adapt offset to larger file sizes
-    if (offset >= fileSize) {
-      //Tell parent function to flush mp4box
-      mp4boxFile.flush();
-      offset = 0;
-      offsetFlag++;
-      if (!gotSamples) read(file, { update, onparsedbuffer, mp4boxFile });
-      return;
-    }
-    read(file, { update, onparsedbuffer, mp4boxFile });
-  };
-  //Use the FileReader
-  r.readAsArrayBuffer(blob);
-}
-
-module.exports = { read, stop };

--- a/index.js
+++ b/index.js
@@ -107,7 +107,7 @@ module.exports = function(file, isBrowser = false, update) {
       };
       // var flush = mp4boxFile.flush;
       //Try to use a web worker to avoid blocking the browser
-      if (typeof Worker !== 'undefined') {
+      if (typeof window !== 'undefined' && window.Worker) {
         worker = new InlineWorker(readBlockWorker, {});
         worker.onmessage = function(e) {
           //Run functions when the web worker requestst them

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var MP4Box = require('mp4box');
-var readBlock = require('./code/readBlock');
+var readBlockFactory = require('./code/readBlock');
 var readBlockWorker = require('./code/readBlockWorker');
 var InlineWorker = require('inline-worker');
 
@@ -31,6 +31,7 @@ module.exports = function(file, isBrowser = false, update) {
   var worker;
   var workerRunning = true;
   return new Promise(function(resolve, reject) {
+    const readBlock = readBlockFactory();
     mp4boxFile = MP4Box.createFile(false);
     var uintArr;
     //Will store timing data to help analyse the extracted data
@@ -106,7 +107,7 @@ module.exports = function(file, isBrowser = false, update) {
       };
       // var flush = mp4boxFile.flush;
       //Try to use a web worker to avoid blocking the browser
-      if (window.Worker) {
+      if (typeof Worker !== 'undefined') {
         worker = new InlineWorker(readBlockWorker, {});
         worker.onmessage = function(e) {
           //Run functions when the web worker requestst them


### PR DESCRIPTION
Hi Juan,

I've been using gmpf-extract in a project of mine. I noticed that extraction caused hangs on the main thread even though it's using a worker. After checking the code I realized that the worker is only used for reading the file, not for MP4Box.

Long story short, I've decided that for my use case it's best to move the entire processing into workers.

I ran into two problems there:

The `readBlock` module is not reentrant. I've solved this by wrapping it with a factory function. 

The check for window.Worker fails in a worker because is window is not defined. I've solved this by adding a simple typeof check.

It's not exactly pretty but should work.

In the future I wonder if it might be best to leave all of the worker specific bits up to the user of the library. It definitely makes sense for my usecase, and I think it likely also makes sense for your gopro telemetry extractor.

Cheers,
Jonas