### PR TITLE
Remove one useless loop in the gpmd extraction

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,9 +77,7 @@ module.exports = function(file, isBrowser = false, update) {
           var runningCount = 0;
           samples.forEach(function(sample) {
             timing.samples.push({ cts: sample.cts, duration: sample.duration });
-            for (var i = 0; i < sample.size; i++) {
-              uintArr.set(sample.data, runningCount);
-            }
+            uintArr.set(sample.data, runningCount);
             runningCount += sample.size;
           });
 


### PR DESCRIPTION
This for loop is not needed. The call to `uintArr.set(buffer, index)` will write the data where we need them and we only need to call this once.

Since this is a for-loop inside a for-loop, I expect this will significantly improve performances. Doing some testing on my side.