### PR TITLE
enable cancellation in browser mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ function toArrayBuffer(buf) {
 
 module.exports = function (
   file,
-  { browserMode, progress, useWorker = true } = {}
+  { browserMode, progress, useWorker = true, cancellationToken } = {}
 ) {
   var mp4boxFile;
   var trackId;
@@ -124,7 +124,11 @@ module.exports = function (
           reject('File not compatible');
         }
         buffer.fileStart = offset;
-        mp4boxFile.appendBuffer(buffer);
+        if (cancellationToken && cancellationToken.cancelled) {
+          if (worker) worker.terminate();
+          else readBlock.stop();
+          resolve(null);
+        } else mp4boxFile.appendBuffer(buffer);
       };
       // var flush = mp4boxFile.flush;
       //Try to use a web worker to avoid blocking the browser

--- a/readme.md
+++ b/readme.md
@@ -28,13 +28,20 @@ You can specify some options in an object as a second argument:
 - **browserMode**: Default: _false_. Change behaviour to use in browser. This is optional for debugging reasons
 - **useWorker**: Default: _true_. In browser mode, use a web worker to avoid locking the browser. This is optional as it seems to crash on some recent browsers
 - **progress**: Pass a function to read the processed percentage updates
+- **cancellationToken**: An optional object, containing a cancelled property, that allows for cancelling the extraction process. Currently only supported in browser mode. If cancelled, the extraction process will return null.
 
 ```js
 const gpmfExtract = require('gpmf-extract');
-const progress = percent => console.log(`${percent}% processed`);
-gpmfExtract(file, { browserMode: true, progress }).then(res => {
-  // Do what you want with the data
-});
+const progress = (percent) => console.log(`${percent}% processed`);
+const cancellationToken = { cancelled: false };
+gpmfExtract(file, { browserMode: true, progress, cancellationToken }).then(
+  (res) => {
+    if (!res) return; //cancelled
+    // Do what you want with the data
+  }
+);
+// Some other processes
+cancellationToken.cancelled = true;
 ```
 
 ## About


### PR DESCRIPTION
addresses https://github.com/JuanIrache/gpmf-extract/issues/49

enables the initiating process to request a cancellation of the extraction process. This only works in browserMode where the reading is done in chunks