### PR TITLE
Remove stray lines from TypeScript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -58,17 +58,3 @@ declare function GPMFExtract(
 
 export default GPMFExtract;
 export { GPMFExtract };
-
-GPMFExtract(
-  file as File,
-  {
-    browserMode: true,
-    cancellationToken: { cancelled: false },
-  }
-)
-GPMFExtract(
-  file as Buffer,
-  {
-    browserMode: false,
-  }
-)


### PR DESCRIPTION
I assume these were used to test the typings while writing them, but they will make a project error.